### PR TITLE
A little bit of refactoring

### DIFF
--- a/pets.json
+++ b/pets.json
@@ -7,7 +7,7 @@
     "caregiver" : "Chris Sienkiewicz",
     "github" : "chsienki",
     "instagram" : "cliffordthebigredrescue",
-    "twitter": "" 
+    "twitter": ""
   },
   {
     "name": "Lucca",
@@ -143,5 +143,5 @@
     "github": "Pilchie",
     "instagram": "k.pilchie",
     "twitter": "Pilchie"
-  }  
+  },
 ]

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,17 +1,18 @@
-﻿using Mustache;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Mustache;
 
 string rootDir = args.Length > 0 ? args[0] : "..\\.";
 
-var template = File.ReadAllText(Path.Combine(rootDir, "template.html"));
-var petData = JsonConvert.DeserializeObject<Pet[]>(File.ReadAllText(Path.Combine(rootDir, "pets.json"))).OrderBy(p => p.name);
+var options = new JsonSerializerOptions() { AllowTrailingCommas = true };
+var petData = JsonSerializer.Deserialize<Pet[]>(File.ReadAllText(Path.Combine(rootDir, "pets.json")), options).OrderBy(p => p.name);
 
+var template = File.ReadAllText(Path.Combine(rootDir, "template.html"));
 var rendered = Template.Compile(template).Render(new { pets = await makeBase64Encoded(petData) });
 File.WriteAllText(Path.Combine(rootDir, "index.html"), rendered);
 
@@ -21,22 +22,34 @@ async static Task<IEnumerable<Pet>> makeBase64Encoded(IEnumerable<Pet> pets)
     var b64Pets = new List<Pet>();
     foreach (var pet in pets)
     {
-        string b64 = string.Empty;
+        var imgData = await getData(client, pet, retryCountOnFailure: 3);
+        string b64 = Convert.ToBase64String(await imgData.Content.ReadAsByteArrayAsync());
+        b64Pets.Add(pet with { img = "data:image/jpeg;base64," + b64 });
+    }
+
+    return b64Pets;
+}
+
+async static Task<HttpResponseMessage> getData(HttpClient client, Pet pet, int retryCountOnFailure)
+{
+    for (int i = 0; i < retryCountOnFailure; i++)
+    {
         try
         {
-            var imgData = await client.GetAsync(pet.img);
-            b64 = Convert.ToBase64String(await imgData.Content.ReadAsByteArrayAsync());
+            return await client.GetAsync(pet.img);
         }
-        catch(Exception e)
+        catch (HttpRequestException e)
         {
-            Console.WriteLine("Couldn't add pet "+pet.name+". Error was "+e.ToString());
-        }
-        finally
-        {
-            b64Pets.Add(pet with { img = "data:image/jpeg;base64," + b64 });
+            // Possible temporarily network error. Keep retry 'retryCountOnFailure' times before throwing.
+            if (i == retryCountOnFailure -1)
+            {
+                Console.WriteLine($"Couldn't add pet {pet.name}. Error was " + e.ToString());
+                throw;
+            }
         }
     }
-    return b64Pets;
+
+    throw new InvalidOperationException("This shouldn't be reachable.");
 }
 
 record Pet(string name, string jobTitle, string img);

--- a/src/SiteBuilder.csproj
+++ b/src/SiteBuilder.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Mustache.NETStandard" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Switched to System.Text.Json that comes with .NET 5+ runtime.
- Avoided silently ignoring image download failure (due to link being invalid, or CI network issue)
- On download failure, retry 3 times to avoid flakiness when there is a temporarily network issue.